### PR TITLE
Add Cloudflare Pages headers file

### DIFF
--- a/public/_headers
+++ b/public/_headers
@@ -1,0 +1,3 @@
+# Remove the ACAO header which is added by default on Cloudflare Pages
+/*
+  ! Access-Control-Allow-Origin


### PR DESCRIPTION
Disable the default behaviour of adding access-control-allow-origin: * to pages sites
