### PR TITLE
Use @username:example.com instead of @username:matrix.org 

### DIFF
--- a/stories/content/VocabularyAndIconography.stories.mdx
+++ b/stories/content/VocabularyAndIconography.stories.mdx
@@ -85,7 +85,7 @@ Below is a list of the most common terms or concepts the average user will come 
     </td>
     <td>
       This is your full identity, which others can use to find you (eg:
-      @username:matrix.org). "Matrix ID" refers to Matrix, the open network
+      @username:example.com). "Matrix ID" refers to Matrix, the open network
       which powers Element, allowing people to communicate and collaborate
       securely. Element, or any other service provider, doesn't own your
       conversations – you do.


### PR DESCRIPTION
`@username:matrix.org` is a random user of matrix.org.
We should better use `example.com` here to avoid spamming them when people are using the example as defaults etc.